### PR TITLE
tests: add timer tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,12 +1,16 @@
 enable_testing()
 
 set (SOURCES
-     timer_test.cpp)
+     ../timer.cpp timer_test.cpp)
 
 set (UNIT_TEST ${PROJECT_NAME}_test)
 
 add_executable(${UNIT_TEST}
                ${SOURCES})
+
+target_include_directories(${UNIT_TEST}
+                           PUBLIC
+                           ${CMAKE_SOURCE_DIR})
 
 target_link_libraries(${UNIT_TEST} gtest)
 

--- a/tests/timer_test.cpp
+++ b/tests/timer_test.cpp
@@ -1,9 +1,89 @@
-#include "../timer.h"
+#include "timer.h"
 
 #include "gtest/gtest.h"
 
-TEST(HelloWorld, BasicAssertionWorksWell) {
-    EXPECT_EQ(1, 1);
+// Constructor puts timer in good state
+  // _running is false
+TEST(TimerTest, ConstructorHappyPath) {
+    Timer t;
+    // some amount of time on the clock
+    ASSERT_GT(t.Remaining(), std::chrono::seconds(0));
+    // TODO - assert not running
+}
+
+// Start() puts timer in good state
+TEST(TimerTest, StartHappyPath) {
+    Timer t;
+
+    t.Start();
+
+    // TODO: check timeRemaining vs default
+    //std::chrono::seconds timediff = std::chrono::duration_cast<std::chrono::seconds>(
+    //    <default time value> - t.Remaining());
+    //ASSERT_GT(timediff, std::chrono::seconds(-1));
+    //ASSERT_LT(timediff, std::chrono::seconds(1));
+    // TODO
+    // _finishTime = now + 10m
+    // _timeRemaining = 10m
+    // _running = true
+}
+
+// Start() is idempotent - I can hit it a lot and nothing happens
+TEST(TimerTest, StartIdempotence) {
+    Timer t;
+
+    t.Start();
+    t.Start();
+}
+
+// Pause() puts timer in good state
+TEST(TimerTest, PauseHappyPath) {
+    Timer t;
+
+    t.Start();
+    t.Pause();
+}
+
+TEST(TimerTest, PauseAlreadyPausedDoesntCrash) {
+    Timer t;
+
+    t.Pause();
+    t.Pause();
+}
+
+// Reset is happy with running timer
+TEST(TimerTest, ResetRunningTimer) {
+    Timer t;
+
+    t.Start();
+    t.Reset();
+    // TODO: test that timer is running afterwards
+}
+
+TEST(TimerTest, ResetStoppedTimer) {
+    Timer t;
+
+    t.Pause();
+    t.Reset();
+}
+
+// CheckTimer() doesn't crash?
+// TODO: check timer when it's expired.
+// This is waiting for runtime-timer-length-config to be useful.
+TEST(TimerTest, CheckTimerHappyPath) {
+    Timer t;
+
+    t.CheckTimer();
+}
+
+// CheckTimer() won't trigger even if it's just paused.
+TEST(TimerTest, CheckTimerWontMisfireOnPause) {
+    Timer t;
+
+    t.Reset();
+    t.Pause();
+
+    ASSERT_FALSE(t.CheckTimer());
 }
 
 int main(int argc, char **argv) {

--- a/timer.cpp
+++ b/timer.cpp
@@ -20,6 +20,10 @@ void Timer::Reset() {
     _running = false;
 }
 
+std::chrono::seconds Timer::Remaining() {
+    return _timeRemaining;
+}
+
 bool Timer::CheckTimer() {
     if (!_running) {
         return false;

--- a/timer.h
+++ b/timer.h
@@ -8,6 +8,7 @@ class Timer {
     void Start();
     void Pause();
     void Reset();
+    std::chrono::seconds Remaining();
 
     bool CheckTimer();
   private:


### PR DESCRIPTION
most of these are still waiting for runtime config of timer length, etc.
for now, just make sure most of it doesn't explode when you run it.