### PR TITLE
chat: close queue on start

### DIFF
--- a/chat.h
+++ b/chat.h
@@ -28,7 +28,7 @@ class Chat {
     std::string LevelListMessage(std::optional<Level> current, PriorityQueso list);
     static std::string GetRemainder(std::stringstream &message);
 
-    bool _canAddToQueue = true;
+    bool _canAddToQueue = false;
     QuesoQueue _qq;
     Timer _timer;
     std::string _priorityText;


### PR DESCRIPTION
this way we can let the bot go up before we're ready to start accepting
levels for the stream.