### PR TITLE
queso: add !dip command to access a level from mid queue

### DIFF
--- a/chat.cpp
+++ b/chat.cpp
@@ -233,6 +233,17 @@ void Chat::HandleMessage(std::stringstream message, std::string sender) {
                                      + l->submitter));
         }
         WriteMessage(NextLevelMessage(l));
+    } else if (command == "dip" && sender == Auth::channel) {
+        std::string username;
+        message >> username;
+        _timer.Reset();
+        std::optional<Level> l = _qq.Dip(username);
+        if (l) {
+            WriteMessage("Here comes the perfect level!");
+            WriteMessage(NextLevelMessage(l));
+        } else {
+            WriteMessage("Dang, I couldn't find a level by " + username + "!");
+        }
     } else if (command == "current") {
         WriteMessage(CurrentLevelMessage(_qq.Current()));
     } else if (command == "list") {

--- a/quesoqueue.cpp
+++ b/quesoqueue.cpp
@@ -217,6 +217,26 @@ std::optional<Level> QuesoQueue::Next() {
     return _current;
 }
 
+std::optional<Level> QuesoQueue::Dip(std::string username) {
+    // Find the earliest submitted level from that username.
+    // Use iterators so we can delete it.
+    for (auto lit = _levels.begin(); lit != _levels.end(); lit++) {
+        // Found it!
+        if (lit->submitter == username) {
+            // Set _current. (This pops the old current.)
+            _current = *lit;
+            // Remove this one from the list.
+            _levels.erase(lit);
+            // We modified the queue, so save.
+            SaveState();
+            // Return the new current.
+            return Current();
+        }
+    }
+    // Didn't find it. :(
+    return std::nullopt;
+}
+
 std::optional<Level> QuesoQueue::Current() {
     //// This is the case when we haven't started yet?
     //if (!_current && !_levels.empty()) {

--- a/quesoqueue.h
+++ b/quesoqueue.h
@@ -47,6 +47,12 @@ class QuesoQueue {
     std::optional<Level> Punt();
 
     /**
+     * Pull the next level from the specified user to the front of the queue.
+     * Pop the current level.
+     */
+    std::optional<Level> Dip(std::string username);
+
+    /**
      * Split the stored level queue into online and offline for printing
      */
     PriorityQueso List();


### PR DESCRIPTION
let the streamer decide to choose a specific level from the queue,
ignoring the online/offline list.

#25 