### PR TITLE
twitch: remove defunct isOnline

### DIFF
--- a/twitch.cpp
+++ b/twitch.cpp
@@ -12,31 +12,6 @@ static size_t CurlWriteCallback(void *contents, size_t size, size_t nmemb,
     return size * nmemb;
 }
 
-bool Twitch::isOnline(std::string username, std::string channel) {
-    CURLcode res;
-    std::string channelUrl = "https://tmi.twitch.tv/group/user/";
-    channelUrl += channel;
-    channelUrl += "/chatters";
-
-    std::string response;
-
-    CURL *curl = curl_easy_init();
-    if (curl) {
-        curl_easy_setopt(curl, CURLOPT_URL, channelUrl.c_str());
-        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlWriteCallback);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
-        res = curl_easy_perform(curl);
-        if (res != CURLE_OK) {
-            std::cerr << "Oh no! curl_easy_perform() failed: "
-                      << curl_easy_strerror(res) << std::endl;
-        }
-        curl_easy_cleanup(curl);
-    }
-
-    // This is a nasty hack.
-    return response.find(username) != response.npos;
-}
-
 std::set<std::string> Twitch::getOnlineUsers(const std::string& channel) {
     CURLcode res;
     std::string channelUrl = "https://tmi.twitch.tv/group/user/";

--- a/twitch.h
+++ b/twitch.h
@@ -5,7 +5,6 @@
 
 class Twitch {
   public:
-    bool isOnline(std::string username, std::string channel);
     std::set<std::string> getOnlineUsers(const std::string& channel);
     void placeStreamMarker();
 


### PR DESCRIPTION
This should have been removed when @diceguyd30 added Twitch::getOnlineUsers().