### PR TITLE
Add an obs text source handler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SOURCES
     quesoqueue.cpp
     chat.cpp
     chips.cpp
+    obs_text_source.cpp
 )
 
 add_executable(

--- a/chat.cpp
+++ b/chat.cpp
@@ -14,7 +14,8 @@
 #include <netdb.h>
 #include <experimental/filesystem>
 
-Chat::Chat(const QuesoQueue &qq, const Timer &timer) : _qq(qq), _timer(timer) {
+Chat::Chat(const QuesoQueue &qq, const Timer &timer, const ObsTextSource &textSource)
+                                    : _qq(qq), _timer(timer), _textSource(textSource) {
     namespace fs = std::experimental::filesystem;
     static const std::regex chipModuleRegex(".*\\.so", std::regex_constants::egrep);
 
@@ -85,6 +86,13 @@ void Chat::Listen() {
             WriteMessage("@" + std::string(Auth::channel) + " the timer has "
                          "expired for this level! Let's roll for retries.");
             WriteMessage("!roll d10");
+
+            // To get the magical 0:00.
+            _textSource.UpdateTime(_timer.Remaining());
+        }
+
+        if (_timer.IsRunning()) {
+            _textSource.UpdateTime(_timer.Remaining());
         }
 
         if (ret == 0) {

--- a/chat.h
+++ b/chat.h
@@ -3,6 +3,7 @@
 // Maybe redundant to Twitch API.
 #include "level.h"
 #include "quesoqueue.h"
+#include "obs_text_source.h"
 #include "timer.h"
 
 #include <string>
@@ -14,7 +15,7 @@
 
 class Chat {
   public:
-    Chat(const QuesoQueue &qq, const Timer &timer);
+    Chat(const QuesoQueue &qq, const Timer &timer, const ObsTextSource &textSource);
     void HandleMessage(std::stringstream message, std::string sender);
     void WriteMessage(std::string message);
     void Write(std::string command);
@@ -31,6 +32,7 @@ class Chat {
     bool _canAddToQueue = false;
     QuesoQueue _qq;
     Timer _timer;
+    ObsTextSource _textSource;
     std::string _priorityText;
 
     std::string _server = "irc.chat.twitch.tv";

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,5 @@
 #include "chat.h"
+#include "obs_text_source.h"
 #include "quesoqueue.h"
 #include "timer.h"
 #include "twitch.h"
@@ -8,7 +9,8 @@ int main(int, char **) {
     QuesoQueue qq(t);
     qq.LoadLastState();
     Timer ti;
-    Chat c(qq, ti);
+    ObsTextSource textSource("textsource.txt");
+    Chat c(qq, ti, textSource);
     c.Connect();
     c.Listen();
 }

--- a/obs_text_source.cpp
+++ b/obs_text_source.cpp
@@ -1,0 +1,23 @@
+#include "obs_text_source.h"
+
+#include <iomanip>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+ObsTextSource::ObsTextSource(std::string path) : _path(path) {
+
+}
+
+
+void ObsTextSource::UpdateTime(std::chrono::seconds seconds) {
+    std::stringstream ss;
+    ss << seconds.count() / 60 << ":" << std::setw(2) << std::setfill('0') << seconds.count() % 60;
+
+    WriteMessage(ss.str());
+}
+
+void ObsTextSource::WriteMessage(std::string message) {
+    std::ofstream textSource(_path, std::ofstream::out);
+    textSource << message;
+}

--- a/obs_text_source.h
+++ b/obs_text_source.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+
+// Add `_path` as a text source in obs to get an onscreen queso-queue timer.
+class ObsTextSource {
+  public:
+    ObsTextSource(std::string path);
+    void UpdateTime(std::chrono::seconds seconds);
+
+  private:
+    void WriteMessage(std::string message);
+    std::string _path;
+};

--- a/timer.cpp
+++ b/timer.cpp
@@ -24,6 +24,10 @@ std::chrono::seconds Timer::Remaining() {
     return _timeRemaining;
 }
 
+bool Timer::IsRunning() {
+    return _running;
+}
+
 bool Timer::CheckTimer() {
     if (!_running) {
         return false;

--- a/timer.h
+++ b/timer.h
@@ -9,6 +9,7 @@ class Timer {
     void Pause();
     void Reset();
     std::chrono::seconds Remaining();
+    bool IsRunning();
 
     bool CheckTimer();
   private:


### PR DESCRIPTION
This gives the streamer the ability to add an onscreen timer for queso queue by setting textsource.txt as a text source in OBS.
In the future this can be updated to display the number of retries rolled by nightbot when the timer hits 0.